### PR TITLE
avd/tracee: Remove AST parsing and change to tracee sigs as library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/aquasecurity/aqua-vulnerability-db-hugo
 go 1.14
 
 require (
-	github.com/aquasecurity/tracee/tracee-rules v0.0.0-20210329225337-50a69404dc29
+	github.com/aquasecurity/tracee/tracee-ebpf v0.0.0-20210408194555-feb16774f64e
+	github.com/aquasecurity/tracee/tracee-rules v0.0.0-20210408194555-feb16774f64e
 	github.com/aquasecurity/vuln-list-update v0.0.0-20191016075347-3d158c2bf9a2
 	github.com/leekchan/gtf v0.0.0-20190214083521-5fba33c5b00b
-	github.com/stretchr/testify v1.6.1
+	github.com/simar7/tracee-signatures/golang v0.0.0-20210409004311-290e0a3715c8
+	github.com/stretchr/testify v1.7.0
 	github.com/umisama/go-cpe v0.0.0-20190323060751-cdd6c3c28a23
 	github.com/valyala/fastjson v1.5.3
 )

--- a/go.sum
+++ b/go.sum
@@ -19,10 +19,12 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210115081842-487d1e44fcda/go.mod h1:Ldem7RTRbX6bdTDxU2eYYvo7pPWYQbbc6rdGv0Ilyts=
-github.com/aquasecurity/tracee/tracee-ebpf v0.0.0-20210217124138-0575cb7b157d h1:7oqrg7UdzFhcJW3kFaISqCAL86ec816GMJ/I8r0Lrdo=
+github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210407135941-e25ba71a024a/go.mod h1:PgXimFYUSx0PfQFRIyl770Jowy6O3r7iJOr39dt1bss=
 github.com/aquasecurity/tracee/tracee-ebpf v0.0.0-20210217124138-0575cb7b157d/go.mod h1:2hx4/WyixWannTcEJEF9Pe9UO5WGrusAyDJIaJ7mmDA=
-github.com/aquasecurity/tracee/tracee-rules v0.0.0-20210329225337-50a69404dc29 h1:wZvwPZ7+Al2y9xvoU06TanJNMulAx/NOarqEoXI0Dko=
-github.com/aquasecurity/tracee/tracee-rules v0.0.0-20210329225337-50a69404dc29/go.mod h1:BVb+BPxY7BYdUuKxtlindLHiyDXuILxuY1QSx8H2vDY=
+github.com/aquasecurity/tracee/tracee-ebpf v0.0.0-20210408194555-feb16774f64e h1:hzv/uc/XFKvJ8ctEDYESscoyCStuf7jPTF4bcTVlwGc=
+github.com/aquasecurity/tracee/tracee-ebpf v0.0.0-20210408194555-feb16774f64e/go.mod h1:a522Pd1sf3azJtAYirWrRRovSt/Hit/rUZaobisOj7Y=
+github.com/aquasecurity/tracee/tracee-rules v0.0.0-20210408194555-feb16774f64e h1:vcyJwLdmc5uPppP0NKn0GQwvrdAGihvmRHHp3Uto0rM=
+github.com/aquasecurity/tracee/tracee-rules v0.0.0-20210408194555-feb16774f64e/go.mod h1:BVb+BPxY7BYdUuKxtlindLHiyDXuILxuY1QSx8H2vDY=
 github.com/aquasecurity/vuln-list-update v0.0.0-20191016075347-3d158c2bf9a2 h1:xbdUfr2KE4THsFx9CFWtWpU91lF+YhgP46moV94nYTA=
 github.com/aquasecurity/vuln-list-update v0.0.0-20191016075347-3d158c2bf9a2/go.mod h1:6NhOP0CjZJL27bZZcaHECtzWdwDDm2g6yCY0QgXEGQQ=
 github.com/araddon/dateparse v0.0.0-20190426192744-0d74ffceef83 h1:ukTLOeMC0aVxbJWVg6hOsVJ0VPIo8w++PbNsze/pqF8=
@@ -282,6 +284,8 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/simar7/tracee-signatures/golang v0.0.0-20210409004311-290e0a3715c8 h1:Ix1RL1Y4L2bz7al98HU77wG7iQ901jjriSL3PNuwa0o=
+github.com/simar7/tracee-signatures/golang v0.0.0-20210409004311-290e0a3715c8/go.mod h1:ADuQwWENLCmaitAj8W/DSxv+d7HkVoQfONoGRbqgHqw=
 github.com/simplereach/timeutils v1.2.0 h1:btgOAlu9RW6de2r2qQiONhjgxdAG7BL6je0G6J/yPnA=
 github.com/simplereach/timeutils v1.2.0/go.mod h1:VVbQDfN/FHRZa1LSqcwo4kNZ62OOyqLLGQKYB3pB0Q8=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -305,8 +309,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/umisama/go-cpe v0.0.0-20190323060751-cdd6c3c28a23 h1:+168JmE638t0OxroPRx7BUbkB91hF3GWS1OkvITgdT0=
@@ -401,8 +405,9 @@ golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210324051608-47abb6519492 h1:Paq34FxTluEPvVyayQqMPgHm+vTOrIifmcYxFBx9TLg=
+golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
This improves upon the AST based logic in favour of simpler tracee signatures as a library way.

requires: Tracee signatures as a library. Currently using: https://github.com/simar7/tracee-signatures

Signed-off-by: Simarpreet Singh <simar@linux.com>