### PR TITLE
fix: Single quotes can trip Hugo YAML unmarshaler.

### DIFF
--- a/docGen/main_test.go
+++ b/docGen/main_test.go
@@ -16,5 +16,5 @@ func (fakeClock) Now(format ...string) string {
 func TestGetAllFiles(t *testing.T) {
 	actual, err := getAllFiles("../goldens/json/nvd")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"../goldens/json/nvd/CVE-2020-0001.json", "../goldens/json/nvd/CVE-2020-0002.json", "../goldens/json/nvd/CVE-2020-11932.json"}, actual)
+	assert.Equal(t, []string{"../goldens/json/nvd/CVE-2020-0001.json", "../goldens/json/nvd/CVE-2020-0002.json", "../goldens/json/nvd/CVE-2020-11932.json", "../goldens/json/nvd/CVE-2022-2788.json"}, actual)
 }

--- a/docGen/nvd.go
+++ b/docGen/nvd.go
@@ -404,7 +404,7 @@ func parseVulnerabilityJSONFile(fileName string) (VulnerabilityPost, error) {
 	if err != nil {
 		return VulnerabilityPost{}, err
 	}
-	vuln.Description = strings.NewReplacer(`"`, ``, `\`, ``).Replace(string(v.GetStringBytes("cve", "description", "description_data", "0", "value")))
+	vuln.Description = strings.NewReplacer(`"`, ``, `\`, ``, `'`, ``).Replace(string(v.GetStringBytes("cve", "description", "description_data", "0", "value")))
 	vuln.ID = string(v.GetStringBytes("cve", "CVE_data_meta", "ID"))
 	vuln.CWEID = string(v.GetStringBytes("cve", "problemtype", "problemtype_data", "0", "description", "0", "value"))
 	vuln.CVSS = CVSS{

--- a/docGen/nvd_test.go
+++ b/docGen/nvd_test.go
@@ -108,6 +108,61 @@ func TestParseVulnerabilityJSONFile(t *testing.T) {
 				},
 			},
 		},
+		{
+			fileName: "../goldens/json/nvd/CVE-2022-2788.json",
+			expectedBlogPost: VulnerabilityPost{
+				Layout: "vulnerability",
+				Title:  "CVE-2022-2788",
+				By:     "NVD",
+				Date:   "2020-01-08 12:19:15 +0000",
+				Vulnerability: Vulnerability{
+					ID:          "CVE-2022-2788",
+					CWEID:       "CWE-269",
+					Description: "Emerson Electrics Proficy Machine Edition Version 9.80 and prior is vulnerable to CWE-29 Path Traversal: ..Filename, also known as a ZipSlip attack, through an upload procedure which enables attackers to implant a malicious .BLZ file on the PLC. The file can transfer through the engineering station onto Windows in a way that executes the malicious code.",
+					References: []string{
+						"https://source.android.com/security/bulletin/2020-01-01",
+					},
+					CVSS: CVSS{
+						V2Vector: "AV:L/AC:L/Au:N/C:C/I:C/A:C",
+						V2Score:  7.2,
+						V3Vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+						V3Score:  7.8,
+					},
+					Dates: Dates{
+						Published: "2020-01-08 12:19:15 +0000",
+						Modified:  "2020-01-14 12:21:52 +0000",
+					},
+					NVDSeverityV2: "HIGH",
+					NVDSeverityV3: "HIGH",
+					AffectedSoftware: []AffectedSoftware{
+						{
+							Name:         "android",
+							Vendor:       "google",
+							StartVersion: "8.0",
+							EndVersion:   "8.0",
+						},
+						{
+							Name:         "android",
+							Vendor:       "google",
+							StartVersion: "8.1",
+							EndVersion:   "8.1",
+						},
+						{
+							Name:         "android",
+							Vendor:       "google",
+							StartVersion: "9.0",
+							EndVersion:   "9.0",
+						},
+						{
+							Name:         "android",
+							Vendor:       "google",
+							StartVersion: "10.0",
+							EndVersion:   "10.0",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		actual, err := parseVulnerabilityJSONFile(tc.fileName)

--- a/goldens/json/nvd/CVE-2022-2788.json
+++ b/goldens/json/nvd/CVE-2022-2788.json
@@ -1,0 +1,112 @@
+{
+  "configurations": {
+    "CVE_data_version": "4.0",
+    "nodes": [
+      {
+        "cpe_match": [
+          {
+            "cpe23Uri": "cpe:2.3:o:google:android:8.0:*:*:*:*:*:*:*",
+            "vulnerable": true
+          },
+          {
+            "cpe23Uri": "cpe:2.3:o:google:android:8.1:*:*:*:*:*:*:*",
+            "vulnerable": true
+          },
+          {
+            "cpe23Uri": "cpe:2.3:o:google:android:9.0:*:*:*:*:*:*:*",
+            "vulnerable": true
+          },
+          {
+            "cpe23Uri": "cpe:2.3:o:google:android:10.0:*:*:*:*:*:*:*",
+            "vulnerable": true
+          }
+        ],
+        "operator": "OR"
+      }
+    ]
+  },
+  "cve": {
+    "CVE_data_meta": {
+      "ASSIGNER": "cve@mitre.org",
+      "ID": "CVE-2022-2788"
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+      "description_data": [
+        {
+          "lang": "en",
+          "value": "Emerson Electric's Proficy Machine Edition Version 9.80 and prior is vulnerable to CWE-29 Path Traversal: '\\..\\Filename', also known as a ZipSlip attack, through an upload procedure which enables attackers to implant a malicious .BLZ file on the PLC. The file can transfer through the engineering station onto Windows in a way that executes the malicious code."
+        }
+      ]
+    },
+    "problemtype": {
+      "problemtype_data": [
+        {
+          "description": [
+            {
+              "lang": "en",
+              "value": "CWE-269"
+            }
+          ]
+        }
+      ]
+    },
+    "references": {
+      "reference_data": [
+        {
+          "name": "https://source.android.com/security/bulletin/2020-01-01",
+          "refsource": "CONFIRM",
+          "tags": [
+            "Vendor Advisory"
+          ],
+          "url": "https://source.android.com/security/bulletin/2020-01-01"
+        }
+      ]
+    }
+  },
+  "impact": {
+    "baseMetricV2": {
+      "acInsufInfo": false,
+      "cvssV2": {
+        "accessComplexity": "LOW",
+        "accessVector": "LOCAL",
+        "authentication": "NONE",
+        "availabilityImpact": "COMPLETE",
+        "baseScore": 7.2,
+        "confidentialityImpact": "COMPLETE",
+        "integrityImpact": "COMPLETE",
+        "vectorString": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
+        "version": "2.0"
+      },
+      "exploitabilityScore": 3.9,
+      "impactScore": 10,
+      "obtainAllPrivilege": false,
+      "obtainOtherPrivilege": false,
+      "obtainUserPrivilege": false,
+      "severity": "HIGH",
+      "userInteractionRequired": false
+    },
+    "baseMetricV3": {
+      "cvssV3": {
+        "attackComplexity": "LOW",
+        "attackVector": "LOCAL",
+        "availabilityImpact": "HIGH",
+        "baseScore": 7.8,
+        "baseSeverity": "HIGH",
+        "confidentialityImpact": "HIGH",
+        "integrityImpact": "HIGH",
+        "privilegesRequired": "LOW",
+        "scope": "UNCHANGED",
+        "userInteraction": "NONE",
+        "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+        "version": "3.1"
+      },
+      "exploitabilityScore": 1.8,
+      "impactScore": 5.9
+    }
+  },
+  "lastModifiedDate": "2020-01-14T21:52Z",
+  "publishedDate": "2020-01-08T19:15Z"
+}


### PR DESCRIPTION
I believe the Hugo unmarshaler is getting tripped up by mismatched single quotes.

# Bad markdown (current)
```
---
title: "CVE-2022-2788"
aliases: [
	"/nvd/cve-2022-2788"
]

shortName: ""
date: 2022-08-19 12:21:15 +0000
category: vulnerabilities
draft: false

avd_page_type: nvd_page

date_published: 
date_modified: 

header_subtitle: ""

sidebar_additional_info_nvd: "https://nvd.nist.gov/vuln/detail/CVE-2022-2788"
sidebar_additional_info_cwe: "https://cwe.mitre.org/data/definitions/29.html"

cvss_nvd_v3_vector: "N/A"
cvss_nvd_v3_score: "0"
cvss_nvd_v3_severity: "N/A"

cvss_nvd_v2_vector: "N/A"
cvss_nvd_v2_score: "0"
cvss_nvd_v2_severity: "N/A"

redhat_v2_vector: "N/A"
redhat_v2_score: "0"
redhat_v2_severity: "N/A"

redhat_v3_vector: "N/A"
redhat_v3_score: "0"
redhat_v3_severity: "N/A"

ubuntu_vector: "N/A"
ubuntu_score: "N/A"
ubuntu_severity: "N/A"

---

https://www.cisa.gov/uscert/ics/advisories/icsa-22-228-06
### Weakness {.with_icon .weakness}
Emerson Electric's Proficy Machine Edition Version 9.80 and prior is vulnerable to CWE-29 Path Traversal: '..Filename', also known as a ZipSlip attack, through an upload procedure which enables attackers to implant a malicious .BLZ file on the PLC. The file can transfer through the engineering station onto Windows in a way that executes the malicious code.

### Affected Software {.with_icon .affected_software}
| Name | Vendor           | Start Version | End Version |
| ------------- |-------------|-----|----|
| Electric's_proficy |  |  | |


### References  {.with_icon .references}

<!--- Add Aqua content below --->
```

Notice the single quote in `Emerson Electric's`

<img width="742" alt="image" src="https://user-images.githubusercontent.com/1254783/188247681-7f5f7f14-6ede-4f1e-89a6-59edfb0795f3.png">


But running `hugo serve -D` locally didn't yield any errors 🤷🏼. Maybe it has been fixed on newer versions, I have `v0.82.0` locally as compared to the `v0.81.0` GitHub Action uses to build.  I didn't try downgrading my version to match the one we run. 

Upgrading the Hugo Version would be another improvement we can make for AVD. PR here: https://github.com/aquasecurity/avd-generator/pull/63 – but this can wait and might not be needed to unblock ourselves currently.

Signed-off-by: Simar <simar@linux.com>