### PR TITLE
fix(nvd): add support of `versionStartExcluding` and `versionEndExcluding`

### DIFF
--- a/docGen/nvd.go
+++ b/docGen/nvd.go
@@ -455,8 +455,8 @@ func parseVulnerabilityJSONFile(fileName string) (VulnerabilityPost, error) {
 			continue
 		}
 
-		startVersion := detectVersion(string(as.GetStringBytes("versionStartIncluding")), string(as.GetStringBytes("versionStartExcluding")), item.Version().String())
-		endVersion := detectVersion(string(as.GetStringBytes("versionEndIncluding")), string(as.GetStringBytes("versionEndExcluding")), item.Version().String())
+		startVersion := detectVersion(string(as.GetStringBytes("versionStartIncluding")), string(as.GetStringBytes("versionStartExcluding")), item)
+		endVersion := detectVersion(string(as.GetStringBytes("versionEndIncluding")), string(as.GetStringBytes("versionEndExcluding")), item)
 
 		affectedSoftware := AffectedSoftware{
 			Name:         item.Product().String(),
@@ -480,7 +480,7 @@ func parseVulnerabilityJSONFile(fileName string) (VulnerabilityPost, error) {
 	}, nil
 }
 
-func detectVersion(includeVersion, excludeVersion, itemVersion string) string {
+func detectVersion(includeVersion, excludeVersion string, item *cpe.Item) string {
 	if includeVersion != "" {
 		return includeVersion + " (including)"
 	}
@@ -489,11 +489,15 @@ func detectVersion(includeVersion, excludeVersion, itemVersion string) string {
 		return excludeVersion + " (excluding)"
 	}
 
-	if itemVersion != "*" {
-		return itemVersion + " (including)"
+	version := item.Version().String()
+	if version != "*" {
+		if update := item.Update().String(); update != "*" && update != "-" {
+			version += "-" + update
+		}
+		return version + " (including)"
 	}
 
-	return itemVersion
+	return version
 }
 
 func VulnerabilityPostToMarkdown(blog VulnerabilityPost, outputFile *os.File, customContent string) error {

--- a/docGen/nvd.go
+++ b/docGen/nvd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"golang.org/x/exp/slices"
 	"io/ioutil"
 	"log"
 	"os"
@@ -454,22 +455,20 @@ func parseVulnerabilityJSONFile(fileName string) (VulnerabilityPost, error) {
 			continue
 		}
 
-		startVersion := string(as.GetStringBytes("versionStartIncluding"))
-		if startVersion == "" {
-			startVersion = item.Version().String()
-		}
+		startVersion := detectVersion(string(as.GetStringBytes("versionStartIncluding")), string(as.GetStringBytes("versionStartExcluding")), item.Version().String())
+		endVersion := detectVersion(string(as.GetStringBytes("versionEndIncluding")), string(as.GetStringBytes("versionEndExcluding")), item.Version().String())
 
-		endVersion := string(as.GetStringBytes("versionEndIncluding"))
-		if endVersion == "" {
-			endVersion = item.Version().String()
-		}
-
-		vuln.AffectedSoftware = append(vuln.AffectedSoftware, AffectedSoftware{
+		affectedSoftware := AffectedSoftware{
 			Name:         item.Product().String(),
 			Vendor:       item.Vendor().String(),
 			StartVersion: startVersion,
 			EndVersion:   endVersion,
-		})
+		}
+
+		// Avoid duplicates
+		if !slices.Contains(vuln.AffectedSoftware, affectedSoftware) {
+			vuln.AffectedSoftware = append(vuln.AffectedSoftware, affectedSoftware)
+		}
 	}
 
 	return VulnerabilityPost{
@@ -479,6 +478,22 @@ func parseVulnerabilityJSONFile(fileName string) (VulnerabilityPost, error) {
 		Date:          publishedDate.UTC().Format("2006-01-02 03:04:05 -0700"),
 		Vulnerability: vuln,
 	}, nil
+}
+
+func detectVersion(includeVersion, excludeVersion, itemVersion string) string {
+	if includeVersion != "" {
+		return includeVersion + " (including)"
+	}
+
+	if excludeVersion != "" {
+		return excludeVersion + " (excluding)"
+	}
+
+	if itemVersion != "*" {
+		return itemVersion + " (including)"
+	}
+
+	return itemVersion
 }
 
 func VulnerabilityPostToMarkdown(blog VulnerabilityPost, outputFile *os.File, customContent string) error {

--- a/docGen/nvd_test.go
+++ b/docGen/nvd_test.go
@@ -560,7 +560,7 @@ An attacker may use the contents of error messages to help launch another, more 
 			b, _ := ioutil.ReadFile(file)
 			assert.NotEmpty(t, b, file)
 
-			if filepath.Base(file) == "CVE-2020-0002.md" {
+			if file == "CVE-2020-0002.md" {
 				assert.Equal(t, `---
 title: "CVE-2020-0002"
 date: 2020-01-08 12:19:15 +0000

--- a/docGen/nvd_test.go
+++ b/docGen/nvd_test.go
@@ -57,8 +57,8 @@ func TestParseVulnerabilityJSONFile(t *testing.T) {
 						{
 							Name:         "android",
 							Vendor:       "google",
-							StartVersion: "9.0 (including)",
-							EndVersion:   "9.0 (including)",
+							StartVersion: "9.0-beta1 (including)",
+							EndVersion:   "9.0-beta1 (including)",
 						},
 						{
 							Name:         "android",
@@ -497,7 +497,7 @@ The software generates an error message that includes sensitive information abou
 | ------------- |-------------|-----|----|
 | Android | Google | 8.0 (including) | 8.0 (including)|
 | Android | Google | 8.1 (including) | 8.1 (including)|
-| Android | Google | 9.0 (including) | 9.0 (including)|
+| Android | Google | 9.0-beta1 (including) | 9.0-beta1 (including)|
 | Android | Google | 10.0 (including) | 10.0 (including)|
 | Red Hat Enterprise Linux 6 Supplementary | RedHat | chromium-browser-80.0.3987.87-1.el6_10 | *|
 | Tar | Ubuntu | bionic | *|

--- a/docGen/nvd_test.go
+++ b/docGen/nvd_test.go
@@ -240,7 +240,7 @@ It was discovered that the Subiquity installer for Ubuntu Server logged the LUKS
 ### Affected Software {.with_icon .affected_software}
 | Name | Vendor           | Start Version | End Version |
 | ------------- |-------------|-----|----|
-| Foo-software | Foo-vendor | 1.2.3 | 4.5.6|
+| Foo-software | Foo-vendor | 1.2.3 (including) | 4.5.6 (excluding)|
 
 
 ### References  {.with_icon .references}
@@ -339,7 +339,7 @@ foo Description
 ### Affected Software {.with_icon .affected_software}
 | Name | Vendor           | Start Version | End Version |
 | ------------- |-------------|-----|----|
-| Foo-software | Foo-vendor | 1.2.3 | 4.5.6|
+| Foo-software | Foo-vendor | 1.2.3 (including) | 4.5.6 (excluding)|
 
 
 ### References  {.with_icon .references}

--- a/docGen/nvd_test.go
+++ b/docGen/nvd_test.go
@@ -45,26 +45,26 @@ func TestParseVulnerabilityJSONFile(t *testing.T) {
 						{
 							Name:         "android",
 							Vendor:       "google",
-							StartVersion: "8.0",
-							EndVersion:   "8.0",
+							StartVersion: "8.0 (including)",
+							EndVersion:   "8.0 (including)",
 						},
 						{
 							Name:         "android",
 							Vendor:       "google",
-							StartVersion: "8.1",
-							EndVersion:   "8.1",
+							StartVersion: "8.1 (including)",
+							EndVersion:   "8.1 (including)",
 						},
 						{
 							Name:         "android",
 							Vendor:       "google",
-							StartVersion: "9.0",
-							EndVersion:   "9.0",
+							StartVersion: "9.0 (including)",
+							EndVersion:   "9.0 (including)",
 						},
 						{
 							Name:         "android",
 							Vendor:       "google",
-							StartVersion: "10.0",
-							EndVersion:   "10.0",
+							StartVersion: "10.0 (including)",
+							EndVersion:   "10.0 (including)",
 						},
 					},
 				},
@@ -102,7 +102,7 @@ func TestParseVulnerabilityJSONFile(t *testing.T) {
 							Name:         "subiquity",
 							Vendor:       "canonical",
 							StartVersion: "*",
-							EndVersion:   "*",
+							EndVersion:   "20.05.2 (excluding)",
 						},
 					},
 				},
@@ -136,7 +136,7 @@ func TestParseVulnerabilityJSONFile(t *testing.T) {
 							Name:         "electric's_proficy",
 							Vendor:       "emerson",
 							StartVersion: "*",
-							EndVersion:   "9.80",
+							EndVersion:   "9.80 (including)",
 						},
 					},
 				},
@@ -187,8 +187,8 @@ func TestVulnerabilityPostToMarkdown(t *testing.T) {
 						{
 							Name:         "foo-software",
 							Vendor:       "foo-vendor",
-							StartVersion: "1.2.3",
-							EndVersion:   "4.5.6",
+							StartVersion: "1.2.3 (including)",
+							EndVersion:   "4.5.6 (excluding)",
 						},
 					},
 				},
@@ -283,8 +283,8 @@ It was discovered that the Subiquity installer for Ubuntu Server logged the LUKS
 						{
 							Name:         "foo-software",
 							Vendor:       "foo-vendor",
-							StartVersion: "1.2.3",
-							EndVersion:   "4.5.6",
+							StartVersion: "1.2.3 (including)",
+							EndVersion:   "4.5.6 (excluding)",
 						},
 					},
 				},
@@ -444,16 +444,22 @@ func TestGenerateVulnerabilityPages(t *testing.T) {
 			b, _ := ioutil.ReadFile(file)
 			assert.NotEmpty(t, b)
 
-			if file == "CVE-2020-0002.md" {
+			if filepath.Base(file) == "CVE-2020-0002.md" {
 				assert.Equal(t, `---
 title: "CVE-2020-0002"
-date: 2020-01-08 12:19:15 +0000
+aliases: [
+	"/nvd/cve-2020-0002"
+]
+
+shortName: "Generation of Error Message Containing Sensitive Information"
+date: 2020-01-08 07:15:12 +0000
+category: vulnerabilities
 draft: false
 
 avd_page_type: nvd_page
 
-date_published: 2020-01-08 12:19:15 +0000
-date_modified: 2020-01-29 12:21:15 +0000
+date_published: 2020-01-08 07:15:12 +0000
+date_modified: 2022-01-01 08:01:34 +0000
 
 header_subtitle: "Generation of Error Message Containing Sensitive Information"
 
@@ -489,10 +495,10 @@ The software generates an error message that includes sensitive information abou
 ### Affected Software {.with_icon .affected_software}
 | Name | Vendor           | Start Version | End Version |
 | ------------- |-------------|-----|----|
-| Android | Google | 1.1.1 | 1.1.1c|
-| Android | Google | 8.1 | 8.1|
-| Android | Google | 9.0 | 9.0|
-| Android | Google | 10.0 | 10.0|
+| Android | Google | 8.0 (including) | 8.0 (including)|
+| Android | Google | 8.1 (including) | 8.1 (including)|
+| Android | Google | 9.0 (including) | 9.0 (including)|
+| Android | Google | 10.0 (including) | 10.0 (including)|
 | Red Hat Enterprise Linux 6 Supplementary | RedHat | chromium-browser-80.0.3987.87-1.el6_10 | *|
 | Tar | Ubuntu | bionic | *|
 | Tar | Ubuntu | cosmic | *|
@@ -554,7 +560,7 @@ An attacker may use the contents of error messages to help launch another, more 
 			b, _ := ioutil.ReadFile(file)
 			assert.NotEmpty(t, b, file)
 
-			if file == "CVE-2020-0002.md" {
+			if filepath.Base(file) == "CVE-2020-0002.md" {
 				assert.Equal(t, `---
 title: "CVE-2020-0002"
 date: 2020-01-08 12:19:15 +0000

--- a/goldens/json/nvd/CVE-2020-0001.json
+++ b/goldens/json/nvd/CVE-2020-0001.json
@@ -89,12 +89,12 @@
             },
             {
               "vulnerable": true,
-              "criteria": "cpe:2.3:o:google:android:8.1:*:*:*:*:*:*:*",
+              "criteria": "cpe:2.3:o:google:android:8.1:-:*:*:*:*:*:*",
               "matchCriteriaId": "B06BE74B-83F4-41A3-8AD3-2E6248F7B0B2"
             },
             {
               "vulnerable": true,
-              "criteria": "cpe:2.3:o:google:android:9.0:*:*:*:*:*:*:*",
+              "criteria": "cpe:2.3:o:google:android:9.0:beta1:*:*:*:*:*:*",
               "matchCriteriaId": "8DFAAD08-36DA-4C95-8200-C29FE5B6B854"
             },
             {

--- a/goldens/json/nvd/CVE-2020-0002.json
+++ b/goldens/json/nvd/CVE-2020-0002.json
@@ -93,12 +93,12 @@
             },
             {
               "vulnerable": true,
-              "criteria": "cpe:2.3:o:google:android:8.1:*:*:*:*:*:*:*",
+              "criteria": "cpe:2.3:o:google:android:8.1:-:*:*:*:*:*:*",
               "matchCriteriaId": "B06BE74B-83F4-41A3-8AD3-2E6248F7B0B2"
             },
             {
               "vulnerable": true,
-              "criteria": "cpe:2.3:o:google:android:9.0:*:*:*:*:*:*:*",
+              "criteria": "cpe:2.3:o:google:android:9.0:beta1:*:*:*:*:*:*",
               "matchCriteriaId": "8DFAAD08-36DA-4C95-8200-C29FE5B6B854"
             },
             {


### PR DESCRIPTION
## Description
- Add support of `versionStartExcluding` and `versionEndExcluding` fields.
- Add `(including)` and `(excluding)` suffixes for versions.
- Add `update` (if used) for versions from CPE

Before:
![изображение](https://github.com/aquasecurity/avd-generator/assets/91113035/12781aeb-ae3f-43bd-a1d0-8592ada2456e)


After:
![изображение](https://github.com/aquasecurity/avd-generator/assets/91113035/a228288e-f1b5-497f-944e-fb31c8f7fb25)
