### PR TITLE
chore(GitHub): Update cron.yml

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -111,7 +111,10 @@ jobs:
           curl -H 'Content-Type: application/json' -H 'X-Meili-API-Key: ${{ secrets.SEARCHAPITOKEN }}' -X POST ${{ secrets.SEARCHAPIHOST }}/indexes/avd/documents --data @docs/searchindex.json
 
       - name: Install AWS CLI
-        run: pip3 install awscli
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip3 install awscli
 
       - name: Sync changes to the bucket
         run: aws s3 sync --no-progress --only-show-errors --size-only avd-repo/docs ${{ secrets.PROD_AVD_BUCKET }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: Build Website
     #    runs-on: ubuntu-20.04
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - name: Set up Go 1.22
         uses: actions/setup-go@v4

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -104,7 +104,10 @@ jobs:
         run: make copy-assets
         
       - name: Install AWS CLI
-        run: pip3 install awscli
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip3 install awscli
 
       - name: Sync changes to the bucket
         run: aws s3 sync --no-progress --only-show-errors --size-only avd-repo/docs ${{ secrets.STAGING_AVD_BUCKET }}


### PR DESCRIPTION
Looks like the runner is failing in the latest release of macOS environment in GitHub Actions. We can pin it to version 13 like so: https://github.com/lammps/lammps/pull/4146/files#diff-aa0563933da21476e08bd72b9ce1988e6d33e60fea45ab3b562ea3da5c5ac2cbR18

