### PR TITLE
ci(cron,staging): use ubuntu runner

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -82,7 +82,7 @@ jobs:
           token: ${{ secrets.ORG_REPO_TOKEN }}
           path: avd-repo/kube-bench-repo
 
-      - name: Checkout private chain-bench-repo
+      - name: Checkout public chain-bench-repo
         uses: actions/checkout@v3
         with:
           repository: aquasecurity/chain-bench

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -7,8 +7,7 @@ on:
 jobs:
   build:
     name: Build Website
-    #    runs-on: ubuntu-20.04
-    runs-on: macos-13
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up Go 1.22
         uses: actions/setup-go@v4

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,9 +16,9 @@ jobs:
         id: go
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: "0.81.0"
+          hugo-version: "0.126.1"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -80,7 +80,7 @@ jobs:
           token: ${{ secrets.ORG_REPO_TOKEN }}
           path: avd-repo/kube-bench-repo
 
-      - name: Checkout private chain-bench-repo
+      - name: Checkout public chain-bench-repo
         uses: actions/checkout@v3
         with:
           repository: aquasecurity/chain-bench

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -14,9 +14,9 @@ jobs:
         id: go
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: "0.81.0"
+          hugo-version: "0.126.1"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -5,8 +5,7 @@ on:
 jobs:
   build:
     name: Build Website - Staging
-    #    runs-on: ubuntu-20.04
-    runs-on: macos-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up Go 1.22
         uses: actions/setup-go@v4


### PR DESCRIPTION
## Description
See #85

- Use `ubuntu-22.04` runner.
- bump `hugo` to `0.126.1` version

Test run - https://github.com/DmitriyLewen/avd-generator/actions/runs/9110598422/job/25045959189
`hugo` created site in 22 min.

