### PR TITLE
ci(cron,staging): add maximize-build-space

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -12,7 +12,8 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 25600 # Hugo is required a lot of free space
+          root-reserve-mb: 13000 # Hugo is required a lot of free space
+          temp-reserve-mb: 13000
           remove-android: 'true'
           remove-docker-images: 'true'
           remove-dotnet: 'true'

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 30720 # Hugo is required a lot of free space
+          root-reserve-mb: 25600 # Hugo is required a lot of free space
           remove-android: 'true'
           remove-docker-images: 'true'
           remove-dotnet: 'true'

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -12,7 +12,6 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 25600 # Hugo is required a lot of free space
           remove-android: 'true'
           remove-docker-images: 'true'
           remove-dotnet: 'true'

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Generate Hugo website
         env:
-          HUGO_CACHEDIR: "./hugo_cache"
+          HUGO_CACHEDIR: $PWD/hugo_cache
         run: |
           mkdir hugo_cache
           make hugo-generate

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -108,10 +108,10 @@ jobs:
         run: make md-generate
 
       - name: Generate Hugo website
-        env:
-          HUGO_CACHEDIR: $PWD/hugo_cache
         run: |
-          mkdir hugo_cache
+          hugo_cache_dir=$(echo "$PWD/hugo_cache")
+          mkdir ${hugo_cache_dir}
+          export HUGO_CACHEDIR=${hugo_cache_dir}
           make hugo-generate
 
       - name: Copy assets

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -110,11 +110,7 @@ jobs:
         run: make md-generate
 
       - name: Generate Hugo website
-        run: |
-          hugo_cache_dir=$(echo "$PWD/hugo_cache")
-          mkdir ${hugo_cache_dir}
-          export HUGO_CACHEDIR=${hugo_cache_dir}
-          make hugo-generate
+        run: make hugo-generate
 
       - name: Copy assets
         run: make copy-assets

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -9,10 +9,20 @@ jobs:
     name: Build Website
     runs-on: ubuntu-22.04
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@v10
+        with:
+          root-reserve-mb: 30720 # Hugo is required a lot of free space
+          remove-android: 'true'
+          remove-docker-images: 'true'
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+
       - name: Set up Go 1.22
         uses: actions/setup-go@v4
         with:
           go-version: '1.22'
+          cache: false
         id: go
 
       - name: Setup Hugo

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -110,7 +110,9 @@ jobs:
       - name: Generate Hugo website
         env:
           HUGO_CACHEDIR: "./hugo_cache"
-        run: make hugo-generate
+        run: |
+          mkdir hugo_cache
+          make hugo-generate
 
       - name: Copy assets
         run: make copy-assets

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
+          root-reserve-mb: 25600 # Hugo is required a lot of free space
           remove-android: 'true'
           remove-docker-images: 'true'
           remove-dotnet: 'true'
@@ -27,7 +28,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: "0.126.1"
+          hugo-version: "0.119.0"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -108,6 +108,8 @@ jobs:
         run: make md-generate
 
       - name: Generate Hugo website
+        env:
+          HUGO_CACHEDIR: "./hugo_cache"
         run: make hugo-generate
 
       - name: Copy assets

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -107,10 +107,10 @@ jobs:
         run: make md-generate
 
       - name: Generate Hugo website
-        env:
-          HUGO_CACHEDIR: $PWD/hugo_cache
         run: |
-          mkdir hugo_cache
+          hugo_cache_dir=$(echo "$PWD/hugo_cache")
+          mkdir ${hugo_cache_dir}
+          export HUGO_CACHEDIR=${hugo_cache_dir}
           make hugo-generate
 
       - name: Copy assets

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -10,7 +10,8 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 25600 # Hugo is required a lot of free space
+          root-reserve-mb: 13000 # Hugo is required a lot of free space
+          temp-reserve-mb: 13000
           remove-android: 'true'
           remove-docker-images: 'true'
           remove-dotnet: 'true'

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -109,7 +109,9 @@ jobs:
       - name: Generate Hugo website
         env:
           HUGO_CACHEDIR: "./hugo_cache"
-        run: make hugo-generate
+        run: |
+          mkdir hugo_cache
+          make hugo-generate
 
       - name: Copy assets
         run: make copy-assets

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -7,10 +7,20 @@ jobs:
     name: Build Website - Staging
     runs-on: ubuntu-22.04
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@v10
+        with:
+          root-reserve-mb: 30720 # Hugo is required a lot of free space
+          remove-android: 'true'
+          remove-docker-images: 'true'
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+
       - name: Set up Go 1.22
         uses: actions/setup-go@v4
         with:
           go-version: '1.22'
+          cache: false
         id: go
 
       - name: Setup Hugo

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: "0.126.1"
+          hugo-version: "0.119.0"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 30720 # Hugo is required a lot of free space
+          root-reserve-mb: 25600 # Hugo is required a lot of free space
           remove-android: 'true'
           remove-docker-images: 'true'
           remove-dotnet: 'true'

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -108,11 +108,7 @@ jobs:
         run: make md-generate
 
       - name: Generate Hugo website
-        run: |
-          hugo_cache_dir=$(echo "$PWD/hugo_cache")
-          mkdir ${hugo_cache_dir}
-          export HUGO_CACHEDIR=${hugo_cache_dir}
-          make hugo-generate
+        run: make hugo-generate
 
       - name: Copy assets
         run: make copy-assets

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -10,6 +10,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
+          root-reserve-mb: 25600 # Hugo is required a lot of free space
           remove-android: 'true'
           remove-docker-images: 'true'
           remove-dotnet: 'true'
@@ -106,6 +107,8 @@ jobs:
         run: make md-generate
 
       - name: Generate Hugo website
+        env:
+          HUGO_CACHEDIR: "./hugo_cache"
         run: make hugo-generate
 
       - name: Copy assets

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Generate Hugo website
         env:
-          HUGO_CACHEDIR: "./hugo_cache"
+          HUGO_CACHEDIR: $PWD/hugo_cache
         run: |
           mkdir hugo_cache
           make hugo-generate

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -10,7 +10,6 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 25600 # Hugo is required a lot of free space
           remove-android: 'true'
           remove-docker-images: 'true'
           remove-dotnet: 'true'


### PR DESCRIPTION
## Description
After upgrading `Hugo` to `0.126.1`, a lot of free space is required - https://github.com/aquasecurity/avd-generator/actions/runs/9122475599/job/25083663442#step:18:9

Add `maximize-build-space` to reallocate space.

## Related PRs
- #87