### PR TITLE
fix(ci): checkout `vuln-list-redhat`

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -41,6 +41,13 @@ jobs:
           token: ${{ secrets.ORG_REPO_TOKEN }}
           path: avd-repo/vuln-list-nvd
 
+      - name: Checkout public vuln-list-redhat-repo
+        uses: actions/checkout@v3
+        with:
+          repository: aquasecurity/vuln-list-redhat
+          token: ${{ secrets.ORG_REPO_TOKEN }}
+          path: avd-repo/vuln-list-redhat
+
       - name: Checkout public kube-hunter-repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   build:
     name: Build Website
-    runs-on: ubuntu-22.04
+    #    runs-on: ubuntu-20.04
+    runs-on: macos-latest
     steps:
       - name: Set up Go 1.22
         uses: actions/setup-go@v4
@@ -16,9 +17,9 @@ jobs:
         id: go
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: "0.126.1"
+          hugo-version: "0.81.0"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
@@ -110,10 +111,7 @@ jobs:
           curl -H 'Content-Type: application/json' -H 'X-Meili-API-Key: ${{ secrets.SEARCHAPITOKEN }}' -X POST ${{ secrets.SEARCHAPIHOST }}/indexes/avd/documents --data @docs/searchindex.json
 
       - name: Install AWS CLI
-        run: |
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip3 install awscli
+        run: pip3 install awscli
 
       - name: Sync changes to the bucket
         run: aws s3 sync --no-progress --only-show-errors --size-only avd-repo/docs ${{ secrets.PROD_AVD_BUCKET }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -103,10 +103,7 @@ jobs:
         run: make copy-assets
         
       - name: Install AWS CLI
-        run: |
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip3 install awscli
+        run: pip3 install awscli
 
       - name: Sync changes to the bucket
         run: aws s3 sync --no-progress --only-show-errors --size-only avd-repo/docs ${{ secrets.STAGING_AVD_BUCKET }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -38,6 +38,14 @@ jobs:
           token: ${{ secrets.ORG_REPO_TOKEN }}
           path: avd-repo/vuln-list-nvd
 
+
+      - name: Checkout public vuln-list-redhat-repo
+        uses: actions/checkout@v3
+        with:
+          repository: aquasecurity/vuln-list-redhat
+          token: ${{ secrets.ORG_REPO_TOKEN }}
+          path: avd-repo/vuln-list-redhat
+
       - name: Checkout public kube-hunter-repo
         uses: actions/checkout@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ md-clone-all:
 	# git clone git@github.com:aquasecurity/avd.git avd-repo/
 	git clone git@github.com:aquasecurity/vuln-list.git avd-repo/vuln-list
 	git clone git@github.com:aquasecurity/vuln-list-nvd.git avd-repo/vuln-list-nvd
+	git clone git@github.com:aquasecurity/vuln-list-redhat.git avd-repo/vuln-list-redhat
 	git clone git@github.com:aquasecurity/kube-hunter.git avd-repo/kube-hunter-repo
 	git clone git@github.com:aquasecurity/kube-bench.git avd-repo/kube-bench-repo
 	git clone git@github.com:aquasecurity/chain-bench.git avd-repo/chain-bench-repo
@@ -26,6 +27,7 @@ md-clone-all:
 update-all-repos:
 	cd avd-repo/vuln-list && git pull
 	cd avd-repo/vuln-list-nvd && git pull
+	cd avd-repo/vuln-list-redhat && git pull
 	cd avd-repo/kube-hunter-repo && git pull
 	cd avd-repo/kube-bench-repo && git pull
 	cd avd-repo/chain-bench-repo && git pull


### PR DESCRIPTION
## Description
RedHat CVSS is always empty - https://avd.aquasec.com/nvd/2022/cve-2022-2000
This happens because we are not retrieving `vuln-list-redhat`.

e.g. https://avd.aquasec.com/nvd/2024/cve-2024-28085/
after changes:
![изображение](https://github.com/aquasecurity/avd-generator/assets/91113035/dbf73143-95f8-4d61-a223-cea0428c2a25)
