### PR TITLE
fix(ci): merge `searchindex.json` after each `hugo` run 

### DIFF
--- a/ci/nvd_pages_build.sh
+++ b/ci/nvd_pages_build.sh
@@ -3,6 +3,10 @@ set -u
 
 CONTENT_NVD_DIR="content-nvd"
 
+## hugo overwrites searchindex.json files after each run.
+## Create all-searchindex.json to combine all indexes from searchindex.json files into this file.
+touch all-searchindex.json
+
 for file in "$CONTENT_NVD_DIR"/*
 do
   YEAR="${file##*/}"
@@ -12,9 +16,14 @@ do
   else
     printf "\n===Building NVD $YEAR pages===\n"
     hugo --destination=docs -c "$CONTENT_NVD_DIR/$YEAR" ## build nvd pages by year
+    ## merge all nvd indexes to all-searchindex.json file
+    jq -sc '.[0] + .[1]' all-searchindex.json docs/searchindex.json > all-searchindex.tmp && mv all-searchindex.tmp all-searchindex.json
   fi
 done
 
 ## build `compliance`, `misconfig`, `tracee` and `nvd/index.md` pages
 printf "\n===Building the remaining content===\n"
 hugo --destination=docs
+
+## merge nvd and other indexes to docs/searchindex.json
+jq -sc '.[0] + .[1]' all-searchindex.json docs/searchindex.json > all-searchindex.tmp && mv all-searchindex.tmp docs/searchindex.json

--- a/config.toml
+++ b/config.toml
@@ -125,3 +125,8 @@ lineNumbersInTable = true
 tabWidth = 4
 noClasses = false
 pygmentsCodefences = true
+
+[markup.goldmark]
+  [markup.goldmark.renderHooks]
+    [markup.goldmark.renderHooks.link]
+      enableDefault = false


### PR DESCRIPTION
## Description
`hugo` overwrites `searchindex.json` file after each run.
We need to merge them.

Also this PR disables [links render](https://gohugo.io/render-hooks/links/#default) to avoid errors when CVE title/description contains wrong link:
```bash
Error: error building site: render: failed to render pages: render of "page" failed: "/home/runner/work/avd-generator/avd-generator/avd-repo/themes/aquablank/layouts/_default/single.html:10:5": execute of template failed: template: _default/single.html:10:5: executing "main" at <partial "page_nvd.html" .>: error calling partial: "/home/runner/work/avd-generator/avd-generator/avd-repo/themes/aquablank/layouts/partials/page_nvd.html:185:10": execute of template failed: template: partials/page_nvd.html:185:10: executing "partials/page_nvd.html" at <.Content>: error calling Content: "/home/runner/work/avd-generator/avd-generator/avd-repo/content-nvd/2015/nvd/2015/CVE-2015-8597.md:1:1": execute of template failed: template: _default/_markup/render-link.html:1:14: executing "_default/_markup/render-link.html" at <urls.Parse>: error calling Parse: parse "http://www.%humbug-URL%.local/bluecoat-splash-API?%BASE64-URL%": invalid URL escape "%hu"
```