### PR TITLE
fix(template): use only `ubuntu_severity` in `page_nvd.html`

### DIFF
--- a/themes/aquablank/layouts/partials/page_nvd.html
+++ b/themes/aquablank/layouts/partials/page_nvd.html
@@ -132,15 +132,11 @@
 
 								</div><!-- score_bar -->
 
-								<div class="score_bar ubuntu {{ if and (not (eq .Params.ubuntu_score "-")) (not (eq .Params.ubuntu_score "N/A")) }}score_bar_{{ math.Round (float (.Params.ubuntu_score)) }}{{ end }}">
+								<div class="score_bar ubuntu">
 									<div class="score_bar_name">Ubuntu</div>
 									<div class="score_bar_image"></div>
-									<div class="score_bar_label">{{ if and (not (eq .Params.ubuntu_score "-")) (not (eq .Params.ubuntu_score "0")) (not (eq .Params.ubuntu_score "N/A")) }}{{ .Params.ubuntu_score }} {{ .Params.ubuntu_severity }}{{ end }}</div>
-									{{ if and (not (eq .Params.ubuntu_vector "-")) (not (eq .Params.ubuntu_vector "")) (not (eq .Params.ubuntu_vector "N/A")) }}
-										<div class="score_bar_vector with_tooltip" data-toggle="tooltip" data-placement="top" data-title="{{ .Params.ubuntu_vector }}">{{ .Params.ubuntu_vector }}</div>
-									{{ else }}
-										<div class="score_bar_vector without_tooltip"></div>
-									{{ end }}
+									<div class="score_bar_label">{{ if and (not (eq .Params.ubuntu_severity "-")) (not (eq .Params.ubuntu_severity "N/A")) }}{{ .Params.ubuntu_severity }}{{ end }}</div>
+									<div class="score_bar_vector without_tooltip"></div>
 
 								</div><!-- score_bar -->
 								


### PR DESCRIPTION
## Description
Ubuntu advisories don't contains `vector` and `score`.
But we can show `severity`.

before:
<img src="https://github.com/aquasecurity/avd-generator/assets/91113035/b337aedb-ff4b-472e-bf19-87eaecaacf84" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="250" />


after:
<img src="https://github.com/aquasecurity/avd-generator/assets/91113035/5de368e8-9b93-460c-8b38-318186bf6d5f" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="250"/>

