### PR TITLE
chore: correctly stop nginx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,11 @@ nginx-start:
 	-cd avd-repo/docs && nginx -p . -c ../../nginx.conf
 
 nginx-stop:
-	-cd avd-repo/docs && nginx -s stop -p . -c ../../nginx.conf
+	@if pgrep nginx > /dev/null; then \
+		cd avd-repo/docs && nginx -s stop -p . -c ../../nginx.conf; \
+	else \
+		echo "Nginx is not running."; \
+	fi
 
 nginx-restart:
 	make nginx-stop nginx-start


### PR DESCRIPTION
Fixes:
```bash
❯ make nginx-stop
cd avd-repo/docs && nginx -s stop -p . -c ../../nginx.conf
nginx: [error] open() "/opt/homebrew/var/run/nginx.pid" failed (2: No such file or directory)
make: [nginx-stop] Error 1 (ignored)
```