### PR TITLE
fix: use correct path to trivy compliances

### DIFF
--- a/docGen/main.go
+++ b/docGen/main.go
@@ -42,7 +42,7 @@ func main() {
 
 	generateChainBenchPages("../avd-repo/chain-bench-repo/internal/checks", "../avd-repo/content/compliance")
 	generateKubeBenchPages("../avd-repo/kube-bench-repo/cfg", "../avd-repo/content/compliance")
-	generateDefsecComplianceSpecPages("../avd-repo/trivy-policies-repo/rules/specs/compliance", "../avd-repo/content/compliance")
+	generateDefsecComplianceSpecPages("../avd-repo/trivy-policies-repo/pkg/specs/compliance", "../avd-repo/content/compliance")
 	generateKubeHunterPages("../avd-repo/kube-hunter-repo/docs/_kb", "../avd-repo/content/misconfig/kubernetes")
 	generateCloudSploitPages("../avd-repo/cloudsploit-repo/plugins", "../avd-repo/content/misconfig", "../avd-repo/remediations-repo/en")
 	if err := generateTraceePages("../avd-repo/tracee-repo/signatures", "../avd-repo/content/tracee", realClock{}); err != nil {


### PR DESCRIPTION
Fixes: https://github.com/aquasecurity/avd-generator/issues/106