### PR TITLE
chore: load checks from repo

### DIFF
--- a/docGen/defsec_test.go
+++ b/docGen/defsec_test.go
@@ -7,18 +7,20 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/iac/rego"
 )
 
 func TestLoadsAsExpected(t *testing.T) {
+	rego.LoadAndRegister()
 
-	tempDir := t.TempDir()
-
-	generateDefsecPages("../goldens/defsec/md", tempDir)
+	outputDir := t.TempDir()
+	generateDefsecPages("../goldens/defsec/md", outputDir)
 
 	ids := []string{"avd-aws-0018"}
 
 	for _, id := range ids {
-		content, err := os.ReadFile(fmt.Sprintf("%s/aws/code-build/%s.md", tempDir, id))
+		content, err := os.ReadFile(fmt.Sprintf("%s/aws/code-build/%s.md", outputDir, id))
 		require.NoError(t, err)
 
 		expected, err := os.ReadFile(fmt.Sprintf("../goldens/defsec/expected/%s.md", id))

--- a/docGen/main.go
+++ b/docGen/main.go
@@ -40,6 +40,10 @@ func main() {
 		Years = append(Years, strconv.Itoa(y))
 	}
 
+	if err := registerChecks(os.DirFS("../avd-repo/trivy-policies-repo")); err != nil {
+		fail(err)
+	}
+
 	generateChainBenchPages("../avd-repo/chain-bench-repo/internal/checks", "../avd-repo/content/compliance")
 	generateKubeBenchPages("../avd-repo/kube-bench-repo/cfg", "../avd-repo/content/compliance")
 	generateDefsecComplianceSpecPages("../avd-repo/trivy-policies-repo/rules/specs/compliance", "../avd-repo/content/compliance")


### PR DESCRIPTION
This PR changes the source of the checks, replacing the checks embedded in Trivy with the trivy-checks repository, which is pulled each time a site is built. This will keep the checks documentation up to date regardless of the version of Trivy.