### PR TITLE
fix(redhat): parse `package_state` for unfixed vulns

### DIFF
--- a/docGen/nvd.go
+++ b/docGen/nvd.go
@@ -423,6 +423,21 @@ func AddVendorInformation(bp *VulnerabilityPost, vendor string, vendorDir string
 			})
 		}
 
+		pkgStates := v.GetArray("package_state")
+		for _, ps := range pkgStates {
+			status := strings.ToLower(string(ps.GetStringBytes("fix_state")))
+			if status == "fixed" || status == "not affected" {
+				continue
+			}
+
+			bp.Vulnerability.AffectedSoftware = append(bp.Vulnerability.AffectedSoftware, AffectedSoftware{
+				Name:         string(ps.GetStringBytes("product_name")),
+				Vendor:       "RedHat",
+				StartVersion: string(ps.GetStringBytes("package_name")),
+				EndVersion:   "*",
+			})
+		}
+
 	case "ubuntu":
 		b, err := ioutil.ReadFile(filepath.Join(vendorDir, fmt.Sprintf("%s.json", bp.Vulnerability.ID)))
 		if err != nil {

--- a/docGen/nvd_test.go
+++ b/docGen/nvd_test.go
@@ -505,6 +505,9 @@ The software generates an error message that includes sensitive information abou
 | Android | Google | 9.0-beta1 (including) | 9.0-beta1 (including)|
 | Android | Google | 10.0 (including) | 10.0 (including)|
 | Red Hat Enterprise Linux 6 Supplementary | RedHat | chromium-browser-80.0.3987.87-1.el6_10 | *|
+| Red Hat Enterprise Linux 5 | RedHat | openssl | *|
+| Red Hat Enterprise Linux 5 | RedHat | openssl097a | *|
+| Red Hat Enterprise Linux 6 | RedHat | openssl | *|
 | Tar | Ubuntu | bionic | *|
 | Tar | Ubuntu | cosmic | *|
 | Tar | Ubuntu | devel | *|

--- a/goldens/json/redhat/2020/CVE-2020-0002.json
+++ b/goldens/json/redhat/2020/CVE-2020-0002.json
@@ -11,19 +11,19 @@
   "package_state": [
     {
       "product_name": "Red Hat Enterprise Linux 5",
-      "fix_state": "Not affected",
+      "fix_state": "Affected",
       "package_name": "openssl",
       "cpe": "cpe:/o:redhat:enterprise_linux:5"
     },
     {
       "product_name": "Red Hat Enterprise Linux 5",
-      "fix_state": "Not affected",
+      "fix_state": "Fix deferred",
       "package_name": "openssl097a",
       "cpe": "cpe:/o:redhat:enterprise_linux:5"
     },
     {
       "product_name": "Red Hat Enterprise Linux 6",
-      "fix_state": "Not affected",
+      "fix_state": "Will not fix",
       "package_name": "openssl",
       "cpe": "cpe:/o:redhat:enterprise_linux:6"
     },


### PR DESCRIPTION
## Description
RedHat uses `affected_release` and `package_state` for packages.
We currently only analyze the `affected_release` array.

That's why we only show fixed vulnerabilities (see https://github.com/aquasecurity/trivy/discussions/8337).

We need to analyze `package_state` to show unpatched vulnerabilities.