### PR TITLE
fix: bypass cloudfront cache for search

### DIFF
--- a/static/js/fastsearch.js
+++ b/static/js/fastsearch.js
@@ -70,7 +70,7 @@ document.getElementById("searchInput").onkeyup = function (e) {
 // apiKey: read-only public secret: https://docs.meilisearch.com/reference/features/authentication.html#key-types
 function loadMeiliSearch() {
     meilisearch = new MeiliSearch({
-        host: 'https://avdsearch.aquasec.com',
+        host: 'http://35.177.163.35',
         apiKey: "d182155a23f2f0acaafbb882a68cbd0080a5b1a47749712d4b704dad03899303", // this is a read-only public key, *not a secret*
     })
     meilisearchIndex = meilisearch.getIndex('avd');


### PR DESCRIPTION
fix and issue with CF where search queries were hitting cache for unrelated entries
we don't really need a cache in front of a serach engine