### PR TITLE
ci: sparse clone only api directory from vuln-list-redhat repo

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -54,6 +54,8 @@ jobs:
         with:
           repository: aquasecurity/vuln-list-redhat
           token: ${{ secrets.ORG_REPO_TOKEN }}
+          sparse-checkout: |
+            api
           path: avd-repo/vuln-list-redhat
 
       - name: Checkout public cloud-security-remediation-guides-repo

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -40,11 +40,7 @@ jobs:
 
 
       - name: Checkout public vuln-list-redhat-repo
-        uses: actions/checkout@v3
-        with:
-          repository: aquasecurity/vuln-list-redhat
-          token: ${{ secrets.ORG_REPO_TOKEN }}
-          path: avd-repo/vuln-list-redhat
+        run: make md-clone-redhat-api
 
       - name: Checkout public cloud-security-remediation-guides-repo
         uses: actions/checkout@v3

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -40,7 +40,13 @@ jobs:
 
 
       - name: Checkout public vuln-list-redhat-repo
-        run: make md-clone-redhat-api
+        uses: actions/checkout@v3
+        with:
+          repository: aquasecurity/vuln-list-redhat
+          token: ${{ secrets.ORG_REPO_TOKEN }}
+          sparse-checkout: |
+            api
+          path: avd-repo/vuln-list-redhat
 
       - name: Checkout public cloud-security-remediation-guides-repo
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -11,20 +11,30 @@ md-test:
 md-clean:
 	rm -f ./generator
 
-md-clone-all:
+
+md-clone-redhat-api:
+	@DIR="avd-repo/vuln-list-redhat"; \
+	git clone --no-checkout --depth=1 --filter=blob:none git@github.com:aquasecurity/vuln-list-redhat.git $$DIR; \
+	git -C "$$DIR" sparse-checkout init --cone; \
+	git -C "$$DIR" sparse-checkout set api; \
+	git -C "$$DIR" read-tree -mu HEAD
+
+md-clone-all: md-clone-redhat-api
 	# git clone git@github.com:aquasecurity/avd.git avd-repo/
 	git clone git@github.com:aquasecurity/vuln-list.git avd-repo/vuln-list
 	git clone git@github.com:aquasecurity/vuln-list-nvd.git avd-repo/vuln-list-nvd
-	git clone git@github.com:aquasecurity/vuln-list-redhat.git avd-repo/vuln-list-redhat
 	git clone git@github.com:aquasecurity/chain-bench.git avd-repo/chain-bench-repo
 	git clone git@github.com:aquasecurity/cloud-security-remediation-guides.git avd-repo/remediations-repo
 	git clone git@github.com:aquasecurity/trivy-policies.git avd-repo/trivy-policies-repo
 	git clone git@github.com:aquasecurity/cloudsploit.git avd-repo/cloudsploit-repo
 
-update-all-repos:
+update-redhat-api:
+	git -C avd-repo/vuln-list-redhat fetch --depth=1
+	git -C avd-repo/vuln-list-redhat reset --hard origin/main
+
+update-all-repos: update-redhat-api
 	cd avd-repo/vuln-list && git pull
 	cd avd-repo/vuln-list-nvd && git pull
-	cd avd-repo/vuln-list-redhat && git pull
 	cd avd-repo/chain-bench-repo && git pull
 	cd avd-repo/remediations-repo && git pull
 	cd avd-repo/trivy-policies-repo && git pull


### PR DESCRIPTION
Significantly reduce clone time from ~16 minutes to just over 2 minutes (≈8× faster) and disk usage from 21 GB to 359 MB (over 50× smaller) by performing a shallow sparse checkout of only the api directory from the vuln-list-redhat repo.

Before:
```bash
❯ time git clone git@github.com:aquasecurity/vuln-list-redhat.git avd-repo/vuln-list-redhat
...
git clone git@github.com:aquasecurity/vuln-list-redhat.git   760.58s user 149.19s system 92% cpu 16:24.60 total
❯ du -sh avd-repo/vuln-list-redhat
 21G    avd-repo/vuln-list-redhat
```

After:
```bash
❯ time make md-clone-redhat-api
...
make md-clone-redhat-api  5.07s user 3.61s system 6% cpu 2:06.13 total
❯ du -sh avd-repo/vuln-list-redhat
359M    avd-repo/vuln-list-redhat
```

How tested: Built the site locally and verified that the pages with Red Hat Vulnerability Advisories successfully loaded and displayed correctly.